### PR TITLE
Fix grouping IHAVE by topic

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
@@ -40,11 +40,9 @@ open class DefaultGossipRpcPartsQueue(
     protected data class IHavePart(val messageId: MessageId, val topic: Topic) : AbstractPart {
         override fun appendToBuilder(builder: Rpc.RPC.Builder) {
             val ctrlBuilder = builder.controlBuilder
-            val iHaveBuilder = if (ctrlBuilder.ihaveBuilderList.isEmpty()) {
-                ctrlBuilder.addIhaveBuilder()
-            } else {
-                ctrlBuilder.getIhaveBuilder(0)
-            }
+            val iHaveBuilder = ctrlBuilder.ihaveBuilderList
+                .find { it.topicID == topic }
+                ?: ctrlBuilder.addIhaveBuilder()
             iHaveBuilder.setTopicID(topic)
             iHaveBuilder.addMessageIDs(messageId.toProtobuf())
         }

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
@@ -1,7 +1,6 @@
 package io.libp2p.pubsub.gossip
 
 import io.libp2p.core.PeerId
-import io.libp2p.etc.types.WBytes
 import io.libp2p.etc.types.toProtobuf
 import io.libp2p.etc.types.toWBytes
 import io.libp2p.pubsub.Topic
@@ -276,8 +275,8 @@ class GossipRpcPartsQueueTest {
         val serialized = res.toByteArray()
         val deserializedRpc = Rpc.RPC.parseFrom(serialized)
         assertThat(deserializedRpc.control.ihaveList).containsExactlyInAnyOrder(
-                Rpc.ControlIHave.newBuilder().setTopicID(topic1).addMessageIDs(messageId1.toProtobuf()).build(),
-                Rpc.ControlIHave.newBuilder().setTopicID(topic2).addMessageIDs(messageId2.toProtobuf()).build(),
+            Rpc.ControlIHave.newBuilder().setTopicID(topic1).addMessageIDs(messageId1.toProtobuf()).build(),
+            Rpc.ControlIHave.newBuilder().setTopicID(topic2).addMessageIDs(messageId2.toProtobuf()).build(),
         )
     }
 
@@ -296,10 +295,12 @@ class GossipRpcPartsQueueTest {
         assertThat(deserializedRpc.control.ihaveList).containsExactlyInAnyOrder(
             Rpc.ControlIHave.newBuilder()
                 .setTopicID("topic1")
-                .addAllMessageIDs(listOf(
-                    "1111".toWBytes().toProtobuf(),
-                    "3333".toWBytes().toProtobuf()
-                )).build(),
+                .addAllMessageIDs(
+                    listOf(
+                        "1111".toWBytes().toProtobuf(),
+                        "3333".toWBytes().toProtobuf()
+                    )
+                ).build(),
             Rpc.ControlIHave.newBuilder()
                 .setTopicID("topic2")
                 .addMessageIDs("2222".toWBytes().toProtobuf()).build(),

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
@@ -264,14 +264,45 @@ class GossipRpcPartsQueueTest {
 
     @Test
     fun `check that resulting IHAVE sets the topic ID`() {
-        val topic: Topic = "topic1"
+        val topic1: Topic = "topic1"
+        val messageId1 = "1111".toWBytes()
+        val topic2: Topic = "topic2"
+        val messageId2 = "2222".toWBytes()
         val partsQueue = TestGossipQueue(gossipParamsWithLimits)
-        partsQueue.addIHave(WBytes(ByteArray(10)), topic)
+        partsQueue.addIHave(messageId1, topic1)
+        partsQueue.addIHave(messageId2, topic2)
         val res = partsQueue.takeMerged().first()
-        assertThat(res.control.ihaveList[0].topicID).isEqualTo(topic)
 
         val serialized = res.toByteArray()
         val deserializedRpc = Rpc.RPC.parseFrom(serialized)
-        assertThat(deserializedRpc.control.ihaveList[0].topicID).isEqualTo(topic)
+        assertThat(deserializedRpc.control.ihaveList).containsExactlyInAnyOrder(
+                Rpc.ControlIHave.newBuilder().setTopicID(topic1).addMessageIDs(messageId1.toProtobuf()).build(),
+                Rpc.ControlIHave.newBuilder().setTopicID(topic2).addMessageIDs(messageId2.toProtobuf()).build(),
+        )
+    }
+
+    @Test
+    fun `check that resulting IHAVE correctly groups topics`() {
+        val partsQueue = TestGossipQueue(gossipParamsWithLimits)
+
+        partsQueue.addIHave("1111".toWBytes(), "topic1")
+        partsQueue.addIHave("2222".toWBytes(), "topic2")
+        partsQueue.addIHave("3333".toWBytes(), "topic1")
+
+        val res = partsQueue.takeMerged().first()
+
+        val serialized = res.toByteArray()
+        val deserializedRpc = Rpc.RPC.parseFrom(serialized)
+        assertThat(deserializedRpc.control.ihaveList).containsExactlyInAnyOrder(
+            Rpc.ControlIHave.newBuilder()
+                .setTopicID("topic1")
+                .addAllMessageIDs(listOf(
+                    "1111".toWBytes().toProtobuf(),
+                    "3333".toWBytes().toProtobuf()
+                )).build(),
+            Rpc.ControlIHave.newBuilder()
+                .setTopicID("topic2")
+                .addMessageIDs("2222".toWBytes().toProtobuf()).build(),
+        )
     }
 }


### PR DESCRIPTION
The modified `check that resulting IHAVE sets the topic ID` test doesn't pass with the original fix, so we still need to dela with grouping topics

- Add grouping when building IHAVEs 
- Add testcases 